### PR TITLE
Improves headings

### DIFF
--- a/src/components/MapForm.js
+++ b/src/components/MapForm.js
@@ -15,6 +15,7 @@ class MapForm extends Component {
  constructor(props) {
    super(props);
    this.state = {
+     pageTitle: "",
      activeMap: {"title": "", },
      addModal: false,
      editable: this.props.match.params.id ? false : true,
@@ -22,6 +23,7 @@ class MapForm extends Component {
  };
  componentDidMount() {
    this.refreshMap();
+   document.title = this.props.match.params.id ? document.title + ": Edit Map" : document.title + ": Add New Map"
  };
  toggleEditable = () => {
    this.setState({editable: !this.state.editable})
@@ -90,6 +92,7 @@ class MapForm extends Component {
  render() {
    return (
      <div>
+      <h1>{this.props.match.params.id ? "Edit Map" : "Add New Map"}</h1>
       <Form className="row mb-4" inline={true}>
         <FormGroup className="col-md-8">
           <Label for="title" hidden>Title</Label>

--- a/src/components/MapList.js
+++ b/src/components/MapList.js
@@ -13,6 +13,7 @@ class MapList extends Component {
  };
  componentDidMount() {
    this.refreshList();
+   document.title = document.title + ": Arrangement Maps";
  };
  toggleModal = map => {
    this.setState({ activeMap: map, deleteModal: !this.state.deleteModal });

--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -65,7 +65,7 @@ export class MapComponentModal extends Component {
     const { toggle } = this.props;
     return (
       <Modal isOpen={true} toggle={toggle} className="modal-md">
-        <ModalHeader toggle={toggle}> Arrangement Map Component </ModalHeader>
+        <ModalHeader tag="h2" toggle={toggle}> Arrangement Map Component </ModalHeader>
         <ModalBody>
           <Row>
             <Col sm="12">
@@ -132,7 +132,7 @@ export class ConfirmModal extends Component {
     const { toggle, message, onConfirm, cancelButtonText, confirmButtonText } = this.props;
     return (
       <Modal isOpen={true} toggle={toggle}>
-        <ModalHeader toggle={toggle}> Confirm Delete </ModalHeader>
+        <ModalHeader tag="h2" toggle={toggle}> Confirm Delete </ModalHeader>
         <ModalBody>
           {message}
         </ModalBody>

--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -76,7 +76,7 @@ export class MapComponentModal extends Component {
             }
             { this.state.activeComponent.archivesspace_uri ? (
               <div className="mt-2">
-                <h2>{this.state.activeComponent.title}</h2>
+                <p className="h5">{this.state.activeComponent.title}</p>
                 <p className="text-muted">{this.state.activeComponent.archivesspace_uri}</p>
                 <Button
                   color="warning"


### PR DESCRIPTION
Adds `h1` tags to all pages
Ensures that the `document.title` (aka the meta title) is appropriately set on all pages
Converts ArchivesSpace resource record title to a regular old `p` tag
Ensures that modal headers are `h2s` 

fixes #29 